### PR TITLE
postcss-import 패키지 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint-plugin-import": "^2.29.1",
         "husky": "^8.0.3",
         "postcss": "^8.4.32",
+        "postcss-import": "^16.0.0",
         "postcss-nesting": "^12.0.2",
         "prettier": "^3.1.1",
         "tailwindcss": "^3.4.0",
@@ -3142,9 +3143,9 @@
       }
     },
     "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.0.0.tgz",
+      "integrity": "sha512-e77lhVvrD1I2y7dYmBv0k9ULTdArgEYZt97T4w6sFIU5uxIHvDFQlKgUUyY7v7Barj0Yf/zm5A4OquZN7jKm5Q==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -3152,7 +3153,7 @@
         "resolve": "^1.1.7"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
@@ -3888,6 +3889,23 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "eslint-plugin-import": "^2.29.1",
     "husky": "^8.0.3",
     "postcss": "^8.4.32",
+    "postcss-import": "^16.0.0",
     "postcss-nesting": "^12.0.2",
     "prettier": "^3.1.1",
     "tailwindcss": "^3.4.0",

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,6 +1,13 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss/base';
+/* @import './custom-base-styles.css'; */
+
+@import 'tailwindcss/components';
+/* @import './custom-components.css'; */
+
+@import 'tailwindcss/utilities';
+/* @import './custom-utilities.css'; */
+
+/* 아래에 css파일 import문 작성해주세요. */
 
 :root {
   font-synthesis: none;


### PR DESCRIPTION
### PR Type 
(PR Type은 하나 이상 선택해주세요.)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
chore/postcss-import -> dev

### 변경 사항
- 각각의 css파일을 메인 css파일에 import할 수 있게 도와주는 postcss-import 패키지 추가
- postcss-import 패키지 적용을 위해 tailwind를 불러오는 구문 수정

### 테스트 결과
ex) 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수 있습니다.
